### PR TITLE
image model updates, small bug fixes and an import script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ CLEAN << 'coverage/'
 CLEAN << 'doc/'
 
 task :environment do
-  require_relative './ash_frame'
+  require_relative './app'
 end
 
 namespace :db do

--- a/app/controllers/gif_controller.rb
+++ b/app/controllers/gif_controller.rb
@@ -1,11 +1,15 @@
 class GifController < ApplicationController
+  get '/gifs*' do
+    pass if Feature.by_name(:gifs, namespace: :public).enabled?
+  end
+
   get '/gifs' do
     @gif_names = Dir[ AshFrame.root.join('public', 'images', 'gifs', '**/*.gif') ].map do |img|
       img.gsub( AshFrame.root.join('public', 'images', 'gifs').to_s + '/', '' )
     end
 
-    @gif_data = Gif.where(file_key: @gif_names).inject({}) do |memo, gif|
-      memo[gif.file_key] = gif
+    @gif_data = Gif.where(filename: @gif_names).inject({}) do |memo, gif|
+      memo[gif.filename] = gif
       memo
     end
 

--- a/app/models/gif.rb
+++ b/app/models/gif.rb
@@ -5,7 +5,7 @@ class Gif < Sequel::Model
 
   def validate
     super
-    validates_presence [ :user_id, :file_key ]
-    validates_unique [ :file_key ]
+    validates_presence [ :user_id, :filename, :short_code ]
+    validates_unique [ :filename, :short_code ]
   end
 end

--- a/app/views/index.haml
+++ b/app/views/index.haml
@@ -1,0 +1,10 @@
+- content_for :title do
+  Home
+
+- content_for :header do
+  %h1.title Home
+
+- content_for :body do
+  %section.section
+    .container
+      %p Nothing to see here, move along.

--- a/bin/importer
+++ b/bin/importer
@@ -9,7 +9,9 @@ require 'zlib'
 
 options = OpenStruct.new(
   images: nil,
-  json:   nil
+  json:   nil,
+  user:   nil,
+  limit:  nil
 )
 
 OptionParser.new do |opts|
@@ -27,8 +29,8 @@ OptionParser.new do |opts|
     options.user = user
   end
 
-  opts.on('-lLIMIT', '--limit=LIMIT', "Limit for the number of images to import") do |user|
-    options.user = user
+  opts.on('-lLIMIT', '--limit=LIMIT', "Limit for the number of images to import") do |limit|
+    options.limit = limit.to_i
   end
 
   opts.on_tail("-h", "--help", "Show this message") do
@@ -55,11 +57,14 @@ metadata_by_filename = metadata.inject({}) do |memo, entry|
   memo
 end
 
+count = 0
 errors = []
 File.open options.images, 'rb' do |file|
   Zlib::GzipReader.wrap file do |gz|
     Gem::Package::TarReader.new gz do |tar|
       tar.each do |entry|
+        break if options.limit && count == options.limit
+
         filename = entry.full_name
         ext = filename.split('.').last
 
@@ -84,6 +89,7 @@ File.open options.images, 'rb' do |file|
                          user: user
 
         print '.'
+        count += 1
       end
     end
   end

--- a/bin/importer
+++ b/bin/importer
@@ -1,0 +1,93 @@
+#!/usr/bin/env ruby
+
+require_relative '../app'
+
+require 'optparse'
+require 'ostruct'
+require 'rubygems/package'
+require 'zlib'
+
+options = OpenStruct.new(
+  images: nil,
+  json:   nil
+)
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: importer -j <json> -i <images> -u <user>"
+
+  opts.on('-iIMAGES', '--images=IMAGES', "Images tar") do |images|
+    options.images = images
+  end
+
+  opts.on('-jJSON', '--json=JSON', "Image metadata JSON") do |json|
+    options.json = json
+  end
+
+  opts.on('-uUSER', '--user=USER', "User ID or username who should own the images") do |user|
+    options.user = user
+  end
+
+  opts.on('-lLIMIT', '--limit=LIMIT', "Limit for the number of images to import") do |user|
+    options.user = user
+  end
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+
+  opts.on_tail("--version", "Show version") do
+    puts '0.0.1'
+    exit
+  end
+end.parse! ARGV
+
+user = User.find{ self.|(id =~ options.user.to_i, username.ilike("%#{ options.user }%")) }
+
+metadata = []
+
+File.open options.json, 'r' do |file|
+  metadata = JSON.parse(file.read)
+end
+
+metadata_by_filename = metadata.inject({}) do |memo, entry|
+  memo[entry['filename']] = entry
+  memo
+end
+
+errors = []
+File.open options.images, 'rb' do |file|
+  Zlib::GzipReader.wrap file do |gz|
+    Gem::Package::TarReader.new gz do |tar|
+      tar.each do |entry|
+        filename = entry.full_name
+        ext = filename.split('.').last
+
+        unless metadata_by_filename.has_key? filename
+          errors << "Image #{ filename } not in image metadata, skipping"
+          next
+        end
+
+        meta = metadata_by_filename[filename]
+        tags = meta['tags'].map{ |tag| tag.gsub '_', ' ' }
+
+        new_filename = [ meta['short_code'], ext ].join '.'
+        new_path = AshFrame.root.join('public', 'images', 'gifs', new_filename)
+
+        new_path.write entry.read
+        Gif.create filename: new_filename,
+                         short_code: meta['short_code'],
+                         title: meta['title'],
+                         tags: tags,
+                         enabled: meta['disable'],
+                         created_at: Time.at(meta['created']),
+                         user: user
+
+        print '.'
+      end
+    end
+  end
+end
+
+puts
+puts errors

--- a/db/migrations/0007_create_gifs.rb
+++ b/db/migrations/0007_create_gifs.rb
@@ -4,12 +4,15 @@ Sequel.migration do
     create_table :gifs do
       primary_key :id
 
-      String :file_key, unique: true, index: true, null: false
+      String :filename,   unique: true, index: true, null: false
+      String :short_code, unique: true, index: true, null: false
 
       String :title
       column :tags, 'text[]'
 
       foreign_key :user_id, :users, index: true
+
+      TrueClass :enabled, default: true, index: true
 
       DateTime :created_at
       DateTime :updated_at


### PR DESCRIPTION
Adds an import script for loading the metadata and images from the Python/RethinkDB transientbug into this version. It also updates the metadata table in Postgres for data I forgot about initially, and does a few small bug fixes.

Images tar archive: https://www.dropbox.com/s/u5fm6vsnfx7bu9n/images.tar.gz?dl=0
Images metadata json: https://www.dropbox.com/s/gh7gj8v0i54isgt/images.json?dl=0

I dumped them into `import/` then ran
`bundle exec bin/importer -j import/images.json -i import/images.tar.gz -u ashby`

You can throw on an optional `-l 10` to limit the number of images to import.
